### PR TITLE
[bugfix] use FullLoader when using yaml.load()

### DIFF
--- a/swg2rst/swagger2rst.py
+++ b/swg2rst/swagger2rst.py
@@ -71,7 +71,7 @@ def main():
 
 def _parse_file(_file):
     try:
-        doc = yaml.load(_file)
+        doc = yaml.load(_file, Loader=yaml.FullLoader)
     except ValueError:
         doc = json.load(_file)
     return doc


### PR DESCRIPTION
## Description
- Fixes the [issue#10](https://github.com/Arello-Mobile/swagger2rst/issues/10) by using `FullLoader` when using the `yaml.load()` function.